### PR TITLE
chore: Resolve RequestConfig.Builder.setConnectTimeout deprecation

### DIFF
--- a/src/main/java/com/github/jowe112/keycloak/mapper/RestApiClient.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/RestApiClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -73,12 +74,16 @@ public final class RestApiClient {
     // ── Construction ─────────────────────────────────────────────────────────
 
     private RestApiClient() {
+        ConnectionConfig connectionConfig = ConnectionConfig.custom()
+                .setConnectTimeout(Timeout.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+                .build();
+
         PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         cm.setMaxTotal(MAX_TOTAL_CONNECTIONS);
         cm.setDefaultMaxPerRoute(MAX_PER_ROUTE);
+        cm.setDefaultConnectionConfig(connectionConfig);
 
         RequestConfig requestConfig = RequestConfig.custom()
-                .setConnectTimeout(Timeout.ofSeconds(CONNECT_TIMEOUT_SECONDS))
                 .setResponseTimeout(Timeout.ofSeconds(RESPONSE_TIMEOUT_SECONDS))
                 .build();
 


### PR DESCRIPTION
## Description
Resolves the deprecation warning in `RestApiClient.java` caused by bumping Apache HttpClient from 5.3.x to 5.6. The `setConnectTimeout` method was removed from `RequestConfig.Builder` and should now be configured on the `PoolingHttpClientConnectionManager` via `ConnectionConfig`.