### PR TITLE
Fix: Endpoint script UI size and correct Jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <httpclient5.version>5.6</httpclient5.version>
 
         <!-- Jackson -->
-        <jackson.version>2.21.1</jackson.version>
+        <jackson.version>2.19.2</jackson.version>
 
         <!-- Jayway JSONPath -->
         <jsonpath.version>3.0.0</jsonpath.version>
@@ -118,6 +118,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
             <scope>compile</scope>
         </dependency>
@@ -226,7 +238,11 @@
                             <!-- Merge SPI service files from all bundled deps -->
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
                             </transformers>
                         </configuration>
                     </execution>

--- a/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
@@ -108,7 +108,7 @@ public class RestClaimMapper extends AbstractOIDCProtocolMapper
                     "JavaScript expression (GraalVM) that builds the query string. "
                             + "Declared query params are available as variables. "
                             + "Example: \"?user=\" + username + \"&mail=\" + email",
-                    ProviderConfigProperty.SCRIPT_TYPE, "\"\""));
+                    ProviderConfigProperty.TEXT_TYPE, "\"\""));
 
             props.add(cfgProp(prefix + ".mapping",
                     "Endpoint " + n + ": Claim Mapping",


### PR DESCRIPTION
## Changes
1. Replaced `SCRIPT_TYPE` (Monaco editor) with `TEXT_TYPE` (resizable textarea) for the **Endpoint Query script** input in Keycloak UI to save vertical space and allow dynamic resizing.
2. Fixed a `NoClassDefFoundError` for `ObjectMapper` by explicitly depending on `jackson-core` and `jackson-annotations` and lowering `jackson.version` to `2.19.2` to match Keycloak's internal classpath resolution rather than conflicting with it.
3. Fixed a `Multi-Release: true` initialisation error for GraalVM Polyglot by configuring `maven-shade-plugin` to inject this header in the output fat JAR manifest.
