### PR TITLE
Fix: Isolate cache keys by mapper ID and invalidate on config changes

### DIFF
--- a/src/main/java/com/github/jowe112/keycloak/mapper/EndpointConfig.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/EndpointConfig.java
@@ -103,4 +103,25 @@ public final class EndpointConfig {
     public boolean isConfigured() {
         return url != null && !url.isBlank();
     }
+
+    /**
+     * Returns a deterministic hash of this endpoint's configuration.
+     * This is used to invalidate the cache immediately if the admin
+     * changes the URL, mapping, script, or auth settings.
+     */
+    public @NotNull String getConfigHash() {
+        int hash = 17;
+        hash = 31 * hash + (url != null ? url.hashCode() : 0);
+        hash = 31 * hash + (authType != null ? authType.hashCode() : 0);
+        hash = 31 * hash + (authValue != null ? authValue.hashCode() : 0);
+        hash = 31 * hash + (queryScript != null ? queryScript.hashCode() : 0);
+        for (String p : queryParams) {
+            hash = 31 * hash + p.hashCode();
+        }
+        for (MappingRule r : mappingRules) {
+            hash = 31 * hash + r.getApiField().hashCode();
+            hash = 31 * hash + r.getClaimName().hashCode();
+        }
+        return Integer.toHexString(hash);
+    }
 }

--- a/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
@@ -208,7 +208,7 @@ public class RestClaimMapper extends AbstractOIDCProtocolMapper
 
             Map<String, Object> claims;
             if (isPersistentUser(user)) {
-                claims = PersistentUserHandler.fetchAndCache(user, endpoints, userCtx, ttl);
+                claims = PersistentUserHandler.fetchAndCache(user, mappingModel.getId(), endpoints, userCtx, ttl);
             } else {
                 claims = TransientUserHandler.fetchLive(endpoints, userCtx);
             }


### PR DESCRIPTION
## Changes
1. **Isolated Cache Keys:** Prepended `mappingModel.getId()` to the Keycloak User Attribute cache keys in `PersistentUserHandler`. This fixes a bug where adding a second REST Endpoint or a second instance of the mapper would hit the cache of the first endpoint and refuse to fetch data until the first endpoint's TTL expired.
2. **Instant Config Invalidation:** Added a `getConfigHash()` method to `EndpointConfig`. The `cached_at` timestamp now stores the config hash alongside the timestamp. If an administrator edits the API URL, Auth type, or Mapping Rules in the Keycloak UI, the cache will instantly invalidate on the next token issuance instead of serving stale data for 300 seconds.
