### PR TITLE
Feat: Add visual endpoint separators to Admin UI

### DIFF
--- a/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/RestClaimMapper.java
@@ -77,6 +77,14 @@ public class RestClaimMapper extends AbstractOIDCProtocolMapper
         for (int n = 1; n <= ConfigParser.MAX_ENDPOINTS; n++) {
             final String prefix = "endpoint." + n;
 
+            if (n > 1) {
+                props.add(cfgProp(prefix + ".separator",
+                        "─── ENDPOINT " + n + " ───",
+                        "Configuration section for Endpoint " + n,
+                        ProviderConfigProperty.STRING_TYPE,
+                        "⬇️ Configure below ⬇️"));
+            }
+
             props.add(cfgProp(prefix + ".url",
                     "Endpoint " + n + ": URL",
                     "Base URL of REST API #" + n + ". Leave blank to disable this slot.",


### PR DESCRIPTION
## Changes
Injected a read-only `ProviderConfigProperty.STRING_TYPE` dummy property before Endpoint 2 and Endpoint 3.
This property acts as a visual divider in the Keycloak Admin Console (which stacks properties vertically), clearly demarcating where the configuration for one endpoint ends and the next begins.
