### PR TITLE
docs: Update GraphQL example and add query script tests

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -180,16 +180,16 @@ query {
 
 ### Mapper Configuration
 
-To achieve this, configure `query.script` to build a valid GraphQL GET query string.
+To achieve this, configure `query.script` to build a valid GraphQL GET query string. Since the query spans multiple lines, you **must use JavaScript template literals (backticks)** instead of regular quotes. 
 
 | Key | Value |
 |---|---|
 | `endpoint.1.url` | `https://api.example.com/graphql` |
 | `endpoint.1.query.param.1` | `username` |
-| `endpoint.1.query.script` | `"?query={ldapUser(uid:\\\"" + username + "\\\"){cn mail memberOf title}}"` |
+| `endpoint.1.query.script` | <code>"?query=" + encodeURIComponent(&#96;query { ldapUser\n(uid: "${username}")\n { cn mail memberOf title } \n}&#96;)</code> |
 | `endpoint.1.mapping` | `$.data.ldapUser.title→job_title, $.data.ldapUser.memberOf→groups` |
 
-*Note the strict escaping of quotes `\"` inside the JavaScript string.*
+*Note how the template literal (the backticks `` ` ``) allows the query string to span multiple lines, and allows direct injection of JS variables with `${username}`.*
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/jowe112/keycloak/mapper/QueryScriptEvaluatorTest.java
+++ b/src/test/java/com/github/jowe112/keycloak/mapper/QueryScriptEvaluatorTest.java
@@ -1,0 +1,14 @@
+package com.github.jowe112.keycloak.mapper;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class QueryScriptEvaluatorTest {
+    @Test
+    public void testActualMultilineInput() {
+        String script = "\"?query=\" + encodeURIComponent(`query { ldapUser\n(uid: \"${username}\")\n { givenName } \n}\n`)";
+        String result = QueryScriptEvaluator.evaluate(script, Map.of("username", "testuser"));
+        assertEquals("?query=query%20%7B%20ldapUser%0A(uid%3A%20%22testuser%22)%0A%20%7B%20givenName%20%7D%20%0A%7D%0A", result);
+    }
+}


### PR DESCRIPTION
Reverts query.script behavior to support standard multi-line GraalVM expressions, and updates documentation to showcase proper template literal usage. Adds JUnit 5 dependencies with test cases for multi-line inputs.