### PR TITLE
docs: Use <pre> and <br> for multi-line query script table rendering

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -186,7 +186,7 @@ To achieve this, configure `query.script` to build a valid GraphQL GET query str
 |---|---|
 | `endpoint.1.url` | `https://api.example.com/graphql` |
 | `endpoint.1.query.param.1` | `username` |
-| `endpoint.1.query.script` | <code>"?query=" + encodeURIComponent(&#96;query { ldapUser\n(uid: "${username}")\n { cn mail memberOf title } \n}&#96;)</code> |
+| `endpoint.1.query.script` | <pre>"?query=" + encodeURIComponent(&#96;query { ldapUser<br>(uid: "${username}")<br> { cn mail memberOf title } <br>}&#96;)</pre> |
 | `endpoint.1.mapping` | `$.data.ldapUser.title→job_title, $.data.ldapUser.memberOf→groups` |
 
 *Note how the template literal (the backticks `` ` ``) allows the query string to span multiple lines, and allows direct injection of JS variables with `${username}`.*


### PR DESCRIPTION
Fixes the Markdown table rendering on GitHub to show physical newlines instead of literal `\n` strings in the multi-line GraphQL template expression.