### PR TITLE
feat: structured JSON claim support via json: prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A **Keycloak 26.x custom OIDC and SAML Protocol Mapper** that enriches federated
 - 🔐 Supports **API key**, **Basic Auth**, and **OAuth2 client credentials** authentication
 - 📜 **GraalVM Polyglot JS** for dynamic query string construction (`query.script`)
 - 🗂️ **JSONPath** (Jayway) and plain field mapping to OIDC claims and SAML attributes
+- 🧩 **Structured JSON claims** — map entire arrays of objects into a single claim with the `json:` prefix (ideal for GraphQL responses)
 - 🧪 **Test Query panel** — live REST endpoint testing via Admin API without a real user login
 - 📦 Deployed as a single fat JAR in `/opt/keycloak/providers/`
 

--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -96,6 +96,57 @@ role→user_role,department→user_dept,$.profile.groups[0]→first_group
 - **Plain name** (`role→user_role`): uses Jackson to read `response["role"]`
 - **JSONPath** (`$.user.profile.dept→user_dept`): uses Jayway JSONPath
 - Multi-value: if the API returns a JSON array, the claim becomes a `List<String>`
+- **Structured JSON** (`$.data.users→json:user_list`): prefix the claim name with `json:` to preserve the full JSON structure (arrays of objects, nested fields). See [Structured JSON Claims](#structured-json-claims) below.
+
+### Structured JSON Claims
+
+By default, arrays returned by the API are flattened to `List<String>` — each element is converted with `.toString()`, and single-element arrays are collapsed to a plain string. This works well for simple lists of scalar values (group names, roles, tags).
+
+When the API returns **arrays of objects** (common with GraphQL), you usually want to preserve the full structure. Prefix the claim name with `json:` to enable structured mode:
+
+```
+$.data.ldapUser→json:users
+```
+
+**Behavior in structured mode:**
+- Arrays of objects → preserved as `List<Map>` (nested objects and arrays intact)
+- Arrays of scalars → preserved as `List<String>` (single-element arrays are **not** collapsed)
+- Scalars → returned as-is
+
+**Example:** Given a GraphQL response:
+
+```json
+{
+  "data": {
+    "ldapUser": [
+      {"cn": "John", "mail": "john@example.com", "memberOf": ["group1", "group2"]},
+      {"cn": "Jane", "mail": "jane@example.com", "memberOf": ["group3"]}
+    ]
+  }
+}
+```
+
+| Mapping | Claim value |
+|---|---|
+| `$.data.ldapUser[0].cn→first_name` | `"John"` (plain string) |
+| `$.data.ldapUser→json:users` | Full array of objects with nested `memberOf` arrays preserved |
+
+The resulting OIDC token claim:
+
+```json
+{
+  "users": [
+    {"cn": "John", "mail": "john@example.com", "memberOf": ["group1", "group2"]},
+    {"cn": "Jane", "mail": "jane@example.com", "memberOf": ["group3"]}
+  ]
+}
+```
+
+> **Token Size Warning:** Putting large arrays of objects into JWT claims increases the token size. Keep the mapped data set small, or use the `userinfo` endpoint for large payloads.
+
+> **SAML:** Structured values are JSON-serialized as a single SAML attribute string value, since SAML attributes are inherently string-based.
+
+> **Persistent User Caching:** Structured values are serialized as JSON strings in Keycloak's `UserModel` attributes and deserialized transparently on cache reads.
 
 ---
 
@@ -199,7 +250,7 @@ To achieve this, configure `query.script` to build a valid GraphQL GET query str
 
 *Note how the template literal (the backticks `` ` ``) allows the query string to span multiple lines, and allows direct injection of JS variables with `${username}`.*
 
-> **Tip on GraphQL Arrays:** If your GraphQL query returns a list/array of items (for example, `{"data": {"ldapUser": [{"id": "jdoe"}]}}`) instead of a single object, you must use array indexing in your JSONPath mapping. For example: `$.data.ldapUser[0].id→user_legacy_id`.
+> **Tip on GraphQL Arrays:** If your GraphQL query returns a list/array of items (for example, `{"data": {"ldapUser": [{"id": "jdoe"}]}}`) instead of a single object, you can either use array indexing to pick individual fields (`$.data.ldapUser[0].id→user_legacy_id`) or use the `json:` prefix to map the entire array as a structured claim (`$.data.ldapUser→json:users`). See [Structured JSON Claims](#structured-json-claims).
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -189,6 +189,16 @@
     <build>
         <plugins>
 
+            <!-- Surefire: set JBoss LogManager before tests touch any logger -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
+                </configuration>
+            </plugin>
+
             <!-- Compiler -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/github/jowe112/keycloak/mapper/EndpointConfig.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/EndpointConfig.java
@@ -121,6 +121,7 @@ public final class EndpointConfig {
         for (MappingRule r : mappingRules) {
             hash = 31 * hash + r.getApiField().hashCode();
             hash = 31 * hash + r.getClaimName().hashCode();
+            hash = 31 * hash + (r.isPreserveJsonStructure() ? 1 : 0);
         }
         return Integer.toHexString(hash);
     }

--- a/src/main/java/com/github/jowe112/keycloak/mapper/JsonPathMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/JsonPathMapper.java
@@ -92,7 +92,7 @@ public final class JsonPathMapper {
             if (value == null)
                 return null;
             if (preserveStructure) {
-                return value;
+                return OBJECT_MAPPER.convertValue(value, Object.class);
             }
             if (value instanceof List<?> list) {
                 List<String> result = new ArrayList<>();

--- a/src/main/java/com/github/jowe112/keycloak/mapper/JsonPathMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/JsonPathMapper.java
@@ -20,6 +20,9 @@ import java.util.Map;
  * Simple field names are resolved with Jackson; JSONPath expressions (starting
  * with {@code "$"}) are resolved with Jayway JSONPath. Scalar values become
  * {@code String}; arrays become {@code List<String>}.
+ * <p>
+ * When a rule has {@link MappingRule#isPreserveJsonStructure()} set, the full
+ * JSON structure is preserved (arrays of objects stay as {@code List<Map>}).
  */
 public final class JsonPathMapper {
 
@@ -53,9 +56,10 @@ public final class JsonPathMapper {
 
         for (MappingRule rule : mappingRules) {
             try {
+                boolean preserve = rule.isPreserveJsonStructure();
                 Object value = rule.isJsonPath()
-                        ? resolveJsonPath(rawJson, rule.getApiField())
-                        : resolveSimpleField(root, rule.getApiField());
+                        ? resolveJsonPath(rawJson, rule.getApiField(), preserve)
+                        : resolveSimpleField(root, rule.getApiField(), preserve);
 
                 if (value != null) {
                     claims.put(rule.getClaimName(), value);
@@ -73,18 +77,23 @@ public final class JsonPathMapper {
 
     // -------------------------------------------------------------------------
 
-    private static @Nullable Object resolveSimpleField(@NotNull JsonNode root, @NotNull String fieldName) {
+    private static @Nullable Object resolveSimpleField(@NotNull JsonNode root, @NotNull String fieldName,
+            boolean preserveStructure) {
         JsonNode node = root.get(fieldName);
         if (node == null || node.isNull())
             return null;
-        return nodeToValue(node);
+        return nodeToValue(node, preserveStructure);
     }
 
-    private static @Nullable Object resolveJsonPath(@NotNull String rawJson, @NotNull String expression) {
+    private static @Nullable Object resolveJsonPath(@NotNull String rawJson, @NotNull String expression,
+            boolean preserveStructure) {
         try {
             Object value = JsonPath.read(rawJson, expression);
             if (value == null)
                 return null;
+            if (preserveStructure) {
+                return value;
+            }
             if (value instanceof List<?> list) {
                 List<String> result = new ArrayList<>();
                 for (Object item : list) {
@@ -99,7 +108,11 @@ public final class JsonPathMapper {
         }
     }
 
-    private static @Nullable Object nodeToValue(@NotNull JsonNode node) {
+    @SuppressWarnings("unchecked")
+    private static @Nullable Object nodeToValue(@NotNull JsonNode node, boolean preserveStructure) {
+        if (preserveStructure) {
+            return OBJECT_MAPPER.convertValue(node, Object.class);
+        }
         if (node.isArray()) {
             List<String> list = new ArrayList<>();
             for (JsonNode element : node) {

--- a/src/main/java/com/github/jowe112/keycloak/mapper/MappingRule.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/MappingRule.java
@@ -10,15 +10,28 @@ import org.jetbrains.annotations.NotNull;
  * JSONPath expression starting with {@code "$"} (e.g.
  * {@code "$.user.profile.dept"}).
  * {@code claimName} is the OIDC claim name to write into the token.
+ * <p>
+ * Prefixing the claim name with {@code json:} (e.g. {@code "json:users"})
+ * preserves the full JSON structure of the resolved value instead of flattening
+ * arrays to {@code List<String>}.
  */
 public final class MappingRule {
 
+    private static final String JSON_PREFIX = "json:";
+
     private final String apiField;
     private final String claimName;
+    private final boolean preserveJsonStructure;
 
     public MappingRule(@NotNull String apiField, @NotNull String claimName) {
         this.apiField = apiField;
-        this.claimName = claimName;
+        if (claimName.startsWith(JSON_PREFIX)) {
+            this.claimName = claimName.substring(JSON_PREFIX.length());
+            this.preserveJsonStructure = true;
+        } else {
+            this.claimName = claimName;
+            this.preserveJsonStructure = false;
+        }
     }
 
     public @NotNull String getApiField() {
@@ -36,8 +49,16 @@ public final class MappingRule {
         return apiField != null && apiField.startsWith("$");
     }
 
+    /**
+     * Returns true if the original claim name was prefixed with {@code json:},
+     * indicating that the resolved value should preserve its full JSON structure.
+     */
+    public boolean isPreserveJsonStructure() {
+        return preserveJsonStructure;
+    }
+
     @Override
     public @NotNull String toString() {
-        return apiField + "→" + claimName;
+        return apiField + "→" + (preserveJsonStructure ? JSON_PREFIX : "") + claimName;
     }
 }

--- a/src/main/java/com/github/jowe112/keycloak/mapper/PersistentUserHandler.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/PersistentUserHandler.java
@@ -1,5 +1,7 @@
 package com.github.jowe112.keycloak.mapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.keycloak.models.UserModel;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,9 @@ import java.util.concurrent.TimeoutException;
 public final class PersistentUserHandler {
 
     private static final Logger LOG = Logger.getLogger(PersistentUserHandler.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String STRUCTURED_PREFIX = "json:";
 
     /** Attribute prefix used for all cache keys written to UserModel. */
     public static final String CACHE_PREFIX = "rest_claim_mapper.";
@@ -145,7 +150,10 @@ public final class PersistentUserHandler {
                     for (Map.Entry<String, Object> entry : mappedClaims.entrySet()) {
                         String attrKey = CACHE_PREFIX + mapperId + "." + entry.getKey();
                         Object val = entry.getValue();
-                        if (val instanceof List<?> list) {
+                        if (isStructuredValue(val)) {
+                            String json = OBJECT_MAPPER.writeValueAsString(val);
+                            user.setSingleAttribute(attrKey, STRUCTURED_PREFIX + json);
+                        } else if (val instanceof List<?> list) {
                             user.setAttribute(attrKey, list.stream().map(Object::toString).toList());
                         } else {
                             user.setSingleAttribute(attrKey, val.toString());
@@ -175,10 +183,30 @@ public final class PersistentUserHandler {
             String attrKey = CACHE_PREFIX + mapperId + "." + rule.getClaimName();
             List<String> values = user.getAttributeStream(attrKey).toList();
             if (!values.isEmpty()) {
-                result.put(rule.getClaimName(), values.size() == 1 ? values.get(0) : values);
+                String first = values.get(0);
+                if (first.startsWith(STRUCTURED_PREFIX)) {
+                    try {
+                        Object parsed = OBJECT_MAPPER.readValue(first.substring(STRUCTURED_PREFIX.length()),
+                                Object.class);
+                        result.put(rule.getClaimName(), parsed);
+                    } catch (JsonProcessingException e) {
+                        LOG.warnf("Failed to deserialize structured cache for claim '%s': %s",
+                                rule.getClaimName(), e.getMessage());
+                    }
+                } else {
+                    result.put(rule.getClaimName(), values.size() == 1 ? first : values);
+                }
             }
         }
         return result;
+    }
+
+    private static boolean isStructuredValue(Object val) {
+        if (val instanceof Map) return true;
+        if (val instanceof List<?> list && !list.isEmpty()) {
+            return list.get(0) instanceof Map;
+        }
+        return false;
     }
 
     /** Builds variable map for the query script from userContext. */

--- a/src/main/java/com/github/jowe112/keycloak/mapper/QueryScriptEvaluator.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/QueryScriptEvaluator.java
@@ -27,6 +27,15 @@ import java.util.Map;
  */
 public final class QueryScriptEvaluator {
 
+    static {
+        // The Truffle native-attach library cannot survive fat-JAR shading, which
+        // produces a noisy WARNING at startup. Functionality is unaffected — scripts
+        // run in interpreter mode, which is perfectly adequate for simple query-string
+        // expressions. Respect any explicit override set via -D on the JVM command line.
+        System.setProperty("polyglotimpl.AttachLibraryFailureAction",
+                System.getProperty("polyglotimpl.AttachLibraryFailureAction", "ignore"));
+    }
+
     private static final Logger LOG = Logger.getLogger(QueryScriptEvaluator.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/src/main/java/com/github/jowe112/keycloak/mapper/SamlRestClaimMapper.java
+++ b/src/main/java/com/github/jowe112/keycloak/mapper/SamlRestClaimMapper.java
@@ -1,5 +1,7 @@
 package com.github.jowe112.keycloak.mapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jboss.logging.Logger;
 import org.keycloak.dom.saml.v2.assertion.AttributeStatementType;
 import org.keycloak.dom.saml.v2.assertion.AttributeType;
@@ -13,6 +15,7 @@ import java.util.*;
 public class SamlRestClaimMapper extends AbstractSAMLProtocolMapper implements SAMLAttributeStatementMapper {
 
     private static final Logger LOG = Logger.getLogger(SamlRestClaimMapper.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     public static final String PROVIDER_ID = "saml-rest-claim-mapper";
     public static final String DISPLAY_TYPE = "SAML REST Attribute Enrichment";
@@ -122,7 +125,13 @@ public class SamlRestClaimMapper extends AbstractSAMLProtocolMapper implements S
                 AttributeType attribute = new AttributeType(claimName);
                 attribute.setNameFormat(nameFormat);
                 
-                if (claimValue instanceof Collection) {
+                if (isStructuredValue(claimValue)) {
+                    try {
+                        attribute.addAttributeValue(OBJECT_MAPPER.writeValueAsString(claimValue));
+                    } catch (JsonProcessingException e) {
+                        LOG.warnf("Failed to serialize structured claim '%s': %s", claimName, e.getMessage());
+                    }
+                } else if (claimValue instanceof Collection) {
                     for (Object val : (Collection<?>) claimValue) {
                         if (val != null) {
                             attribute.addAttributeValue(val.toString());
@@ -140,6 +149,14 @@ public class SamlRestClaimMapper extends AbstractSAMLProtocolMapper implements S
         } catch (Exception e) {
             LOG.errorf(e, "SamlRestClaimMapper: unexpected error — claims skipped for session %s", userSession.getId());
         }
+    }
+
+    private static boolean isStructuredValue(Object val) {
+        if (val instanceof Map) return true;
+        if (val instanceof List<?> list && !list.isEmpty()) {
+            return list.get(0) instanceof Map;
+        }
+        return false;
     }
 
     private String getSAMLNameFormat(String nameFormat) {

--- a/src/test/java/com/github/jowe112/keycloak/mapper/JsonPathMapperTest.java
+++ b/src/test/java/com/github/jowe112/keycloak/mapper/JsonPathMapperTest.java
@@ -1,0 +1,214 @@
+package com.github.jowe112.keycloak.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JsonPathMapperTest {
+
+    // ── Backward-compatible (no json: prefix) ────────────────────────────────
+
+    @Test
+    void simpleFieldScalar() {
+        String json = """
+                {"role": "admin", "department": "engineering"}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("role", "user_role"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals("admin", claims.get("user_role"));
+    }
+
+    @Test
+    void simpleFieldArrayOfStringsCollapseSingle() {
+        String json = """
+                {"tags": ["only-one"]}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("tags", "user_tags"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals("only-one", claims.get("user_tags"));
+    }
+
+    @Test
+    void simpleFieldArrayOfStringsMultiple() {
+        String json = """
+                {"tags": ["a", "b", "c"]}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("tags", "user_tags"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals(List.of("a", "b", "c"), claims.get("user_tags"));
+    }
+
+    @Test
+    void jsonPathScalar() {
+        String json = """
+                {"data": {"user": {"name": "John"}}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.user.name", "user_name"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals("John", claims.get("user_name"));
+    }
+
+    @Test
+    void jsonPathArrayOfStringsCollapseSingle() {
+        String json = """
+                {"data": {"groups": ["admins"]}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.groups[0]", "group"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals("admins", claims.get("group"));
+    }
+
+    @Test
+    void jsonPathArrayOfStringsMultiple() {
+        String json = """
+                {"data": {"groups": ["admins", "devs", "ops"]}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.groups", "groups"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals(List.of("admins", "devs", "ops"), claims.get("groups"));
+    }
+
+    // ── Structured mode (json: prefix) ───────────────────────────────────────
+
+    @Test
+    void jsonPrefixJsonPathArrayOfObjects() {
+        String json = """
+                {
+                  "data": {
+                    "ldapUser": [
+                      {"cn": "John", "mail": "john@example.com"},
+                      {"cn": "Jane", "mail": "jane@example.com"}
+                    ]
+                  }
+                }
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.ldapUser", "json:users"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        Object value = claims.get("users");
+        assertInstanceOf(List.class, value);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> users = (List<Map<String, Object>>) value;
+        assertEquals(2, users.size());
+        assertEquals("John", users.get(0).get("cn"));
+        assertEquals("jane@example.com", users.get(1).get("mail"));
+    }
+
+    @Test
+    void jsonPrefixJsonPathSingleElementArrayNotCollapsed() {
+        String json = """
+                {"data": {"items": ["only-one"]}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.items", "json:items"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        Object value = claims.get("items");
+        assertInstanceOf(List.class, value);
+        assertEquals(List.of("only-one"), value);
+    }
+
+    @Test
+    void jsonPrefixSimpleFieldArrayOfObjects() {
+        String json = """
+                {
+                  "users": [
+                    {"id": 1, "name": "Alice"},
+                    {"id": 2, "name": "Bob"}
+                  ]
+                }
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("users", "json:all_users"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        Object value = claims.get("all_users");
+        assertInstanceOf(List.class, value);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> users = (List<Map<String, Object>>) value;
+        assertEquals(2, users.size());
+        assertEquals(1, users.get(0).get("id"));
+        assertEquals("Bob", users.get(1).get("name"));
+    }
+
+    @Test
+    void jsonPrefixScalarPassedThrough() {
+        String json = """
+                {"data": {"count": 42}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.count", "json:total"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertEquals(42, claims.get("total"));
+    }
+
+    @Test
+    void jsonPrefixNestedObjects() {
+        String json = """
+                {
+                  "data": {
+                    "ldapUser": [
+                      {
+                        "cn": "John",
+                        "memberOf": ["group1", "group2"],
+                        "title": {"org": "Engineering"}
+                      }
+                    ]
+                  }
+                }
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.ldapUser", "json:users"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> users = (List<Map<String, Object>>) claims.get("users");
+        assertEquals(1, users.size());
+        assertEquals(List.of("group1", "group2"), users.get(0).get("memberOf"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> title = (Map<String, Object>) users.get(0).get("title");
+        assertEquals("Engineering", title.get("org"));
+    }
+
+    // ── Edge cases ───────────────────────────────────────────────────────────
+
+    @Test
+    void nullJsonReturnsEmpty() {
+        Map<String, Object> claims = JsonPathMapper.map(null, List.of(new MappingRule("x", "y")));
+        assertTrue(claims.isEmpty());
+    }
+
+    @Test
+    void nullRulesReturnsEmpty() {
+        Map<String, Object> claims = JsonPathMapper.map("{\"x\":1}", null);
+        assertTrue(claims.isEmpty());
+    }
+
+    @Test
+    void missingFieldReturnsEmpty() {
+        String json = """
+                {"role": "admin"}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("nonexistent", "claim"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertNull(claims.get("claim"));
+    }
+
+    @Test
+    void missingJsonPathReturnsEmpty() {
+        String json = """
+                {"data": {"x": 1}}
+                """;
+        List<MappingRule> rules = List.of(new MappingRule("$.data.missing.path", "claim"));
+        Map<String, Object> claims = JsonPathMapper.map(json, rules);
+
+        assertNull(claims.get("claim"));
+    }
+}

--- a/src/test/java/com/github/jowe112/keycloak/mapper/MappingRuleTest.java
+++ b/src/test/java/com/github/jowe112/keycloak/mapper/MappingRuleTest.java
@@ -1,0 +1,38 @@
+package com.github.jowe112.keycloak.mapper;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MappingRuleTest {
+
+    @Test
+    void plainClaimName() {
+        MappingRule rule = new MappingRule("role", "user_role");
+        assertEquals("user_role", rule.getClaimName());
+        assertFalse(rule.isPreserveJsonStructure());
+        assertEquals("role→user_role", rule.toString());
+    }
+
+    @Test
+    void jsonPrefixStripped() {
+        MappingRule rule = new MappingRule("$.data.users", "json:users");
+        assertEquals("users", rule.getClaimName());
+        assertTrue(rule.isPreserveJsonStructure());
+        assertTrue(rule.isJsonPath());
+    }
+
+    @Test
+    void toStringIncludesJsonPrefix() {
+        MappingRule rule = new MappingRule("$.items", "json:items");
+        assertEquals("$.items→json:items", rule.toString());
+    }
+
+    @Test
+    void jsonPrefixOnSimpleField() {
+        MappingRule rule = new MappingRule("data", "json:payload");
+        assertEquals("payload", rule.getClaimName());
+        assertTrue(rule.isPreserveJsonStructure());
+        assertFalse(rule.isJsonPath());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `json:` prefix syntax to mapping rules (e.g. `$.data.User[0].team→json:teams`) that preserves the full JSON structure of arrays and objects instead of flattening to `List<String>`
- Normalizes JSONPath output through Jackson to guarantee well-formed JSON in the token
- Handles persistent user cache serialization/deserialization for structured values
- SAML: structured values are JSON-serialized as a single attribute string
- Suppresses spurious GraalVM `truffleattach` and JBoss LogManager warnings at startup

## Test plan

- [ ] `mvn clean package` builds without errors
- [ ] Configure a mapping like `$.data.User[0].team→json:teams` and verify the token claim contains the full array of objects
- [ ] Verify existing plain field and JSONPath mappings still work unchanged