### PR TITLE
docs: add tip for forcing string output using [0] array indexing

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -98,6 +98,12 @@ role→user_role,department→user_dept,$.profile.groups[0]→first_group
 - Multi-value: if the API returns a JSON array, the claim becomes a `List<String>`
 - **Structured JSON** (`$.data.users→json:user_list`): prefix the claim name with `json:` to preserve the full JSON structure (arrays of objects, nested fields). See [Structured JSON Claims](#structured-json-claims) below.
 
+> **Tip — force a string output:** If the resolved value is an array but you only want a single string in the claim, append `[0]` to the JSONPath expression to select the first element:
+> ```
+> $.data.User[0].team[0].name→team_name
+> ```
+> Result: `"team_name": "Team IAM"` (string, not an array).
+
 ### Structured JSON Claims
 
 By default, arrays returned by the API are flattened to `List<String>` — each element is converted with `.toString()`, and single-element arrays are collapsed to a plain string. This works well for simple lists of scalar values (group names, roles, tags).


### PR DESCRIPTION
## Summary

- Adds a tip to the Claim Mapping Syntax section in `ADMIN_GUIDE.md` explaining that appending `[0]` to a JSONPath expression selects the first element of an array, producing a plain string claim value instead of an array.

## Test plan

- [ ] Read the updated section in `ADMIN_GUIDE.md` and verify the tip is clear and correctly placed