### PR TITLE
fix: require realm-admin auth on Test Query endpoint (#56)

### DIFF
--- a/docs/ADMIN_GUIDE.md
+++ b/docs/ADMIN_GUIDE.md
@@ -171,6 +171,8 @@ Authorization: Bearer <admin-token>
 Content-Type: application/json
 ```
 
+> **Authorization required.** This endpoint makes Keycloak issue a live HTTP request to the URL you supply and returns the response, so it is restricted to realm admins. The bearer token must belong to a user holding the realm-management **`manage-clients`** role *in the target realm* (the `realm-admin` composite includes it). Requests with no/invalid token receive **401**; authenticated non-admins receive **403**. Because the check is scoped to the target realm, obtain the token from that realm — a token from a different realm (e.g. `master`) will not be accepted.
+
 **Request body:**
 ```json
 {
@@ -202,10 +204,13 @@ Content-Type: application/json
 
 ### Getting an Admin Token
 
+Obtain the token from the **same realm** you are testing (`myrealm` below), using an
+account that holds the realm-management `manage-clients` (or `realm-admin`) role:
+
 ```bash
 TOKEN=$(curl -s -X POST \
-  "https://keycloak.example.com/realms/master/protocol/openid-connect/token" \
-  -d "client_id=admin-cli&grant_type=password&username=admin&password=<pw>" \
+  "https://keycloak.example.com/realms/myrealm/protocol/openid-connect/token" \
+  -d "client_id=admin-cli&grant_type=password&username=<realm-admin>&password=<pw>" \
   | jq -r .access_token)
 
 curl -s -X POST \

--- a/src/main/java/com/github/jowe112/keycloak/admin/TestQueryResourceProvider.java
+++ b/src/main/java/com/github/jowe112/keycloak/admin/TestQueryResourceProvider.java
@@ -7,7 +7,15 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
+import org.keycloak.models.AdminRoles;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.Constants;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager.AuthResult;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 import java.util.List;
@@ -31,8 +39,10 @@ public class TestQueryResourceProvider implements RealmResourceProvider {
     private static final Logger LOG = Logger.getLogger(TestQueryResourceProvider.class);
     private static final ObjectMapper JSON = new ObjectMapper();
 
+    private final KeycloakSession session;
+
     public TestQueryResourceProvider(KeycloakSession session) {
-        // session not needed for this stateless resource
+        this.session = session;
     }
 
     @Override
@@ -83,6 +93,11 @@ public class TestQueryResourceProvider implements RealmResourceProvider {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response testQuery(TestQueryRequest req) {
+        // Authenticate and authorize BEFORE any request parsing or outbound HTTP
+        // call — this endpoint makes Keycloak issue live requests to a caller-supplied
+        // URL and reflects the response, so it must be restricted to realm admins.
+        requireRealmAdmin();
+
         TestQueryResponse resp = new TestQueryResponse();
 
         try {
@@ -132,6 +147,38 @@ public class TestQueryResourceProvider implements RealmResourceProvider {
             return Response.ok(JSON.writeValueAsString(resp)).build();
         } catch (Exception e) {
             return Response.serverError().entity("{\"error\":\"Serialization failed\"}").build();
+        }
+    }
+
+    // ── Authorization ─────────────────────────────────────────────────────────
+
+    /**
+     * Ensures the caller presents a valid bearer token for a user who holds the
+     * realm-management {@code manage-clients} admin role (the same permission
+     * required to configure this mapper). The {@code realm-admin} composite
+     * includes this role, so full realm admins also pass.
+     *
+     * @throws NotAuthorizedException (401) if no valid bearer token is present
+     * @throws ForbiddenException     (403) if the user is not a realm admin
+     */
+    private void requireRealmAdmin() {
+        AuthResult auth = new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
+        if (auth == null || auth.getUser() == null) {
+            throw new NotAuthorizedException("A valid admin bearer token is required");
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+        ClientModel realmMgmt = realm.getClientByClientId(Constants.REALM_MANAGEMENT_CLIENT_ID);
+        if (realmMgmt == null) {
+            LOG.errorf("realm-management client not found in realm '%s'", realm.getName());
+            throw new ForbiddenException("Admin role required");
+        }
+
+        RoleModel manageClients = realmMgmt.getRole(AdminRoles.MANAGE_CLIENTS);
+        UserModel user = auth.getUser();
+        if (manageClients == null || !user.hasRole(manageClients)) {
+            throw new ForbiddenException("Requires the realm-management '"
+                    + AdminRoles.MANAGE_CLIENTS + "' role");
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes an **unauthenticated SSRF** in the Test Query endpoint (`POST /realms/{realm}/rest-claim-mapper/test-query`).

Keycloak `RealmResourceProvider` endpoints are public by default. This one took a caller-supplied `url`, made Keycloak issue a live HTTP GET to it, and reflected the response body back — so anyone who could reach the realm endpoint could make Keycloak call arbitrary internal URLs (cloud metadata, internal services) and read the responses, with attacker-supplied credentials attached.

## Change

- Add `requireRealmAdmin()` guard, called before any request parsing or HTTP call:
  - Authenticate the bearer token via `AppAuthManager.BearerTokenAuthenticator`.
  - Require the realm-management `manage-clients` role (the `realm-admin` composite includes it).
  - No/invalid token → **401**; authenticated non-admin → **403**.
- Provider now retains the `KeycloakSession` (was discarded).
- Docs updated: state the authorization requirement; obtain the token from the **target realm** (a master-realm token is not accepted by the realm-scoped check).

All auth classes used are from the existing `provided` keycloak-services / keycloak-server-spi-private deps.

## Test plan

- [x] `mvn clean package` builds, all 20 tests pass
- [ ] Manual against running Keycloak:
  - No token → 401
  - Non-admin user token → 403
  - Realm-admin token (from the target realm) → 200, response shape unchanged

Closes #56